### PR TITLE
Added version number 1.0.0 in manifest.json

### DIFF
--- a/whirlpool/manifest.json
+++ b/whirlpool/manifest.json
@@ -8,5 +8,6 @@
   ],
   "codeowners": [
     "@abmantis"
-  ]
+  ],
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Custom components will be required to have a version number in Home Assistant in the future for them to load.